### PR TITLE
msys2

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Für die meisten Übungen insbesondere die C-Übungen benötigen Sie ein Linux S
 * Sie verwenden bereits Linux (Ubuntu, Debian etc.) ✅
 * Sie verwenden MacOS ✅
 * Sie verwenden [Windows 10 mit Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install-win10) ✅
+* Sie verwenden [MSYS2](https://www.msys2.org)
 * Frühere Windows Version ❌
 
 Testen ob `gcc` installiert ist. 


### PR DESCRIPTION
[MSYS2](https://www.msys2.org) bietet eine UNIX-Umgebung für Windows an.

Es gibt verschiedene [Presets](https://www.msys2.org/docs/environments/).
Zu empfehlen ist UCRT64, hier bekommt man GCC für 64 Bit.
Spezifisch für ARM gibt es CLANGARM64, hier wird aber LLVM (Clang) verwendet.

Die Build Tools kommen von [mingw-w64](https://www.mingw-w64.org).
Diese sind auch einzeln installierbar.
[MSYS2](https://www.msys2.org) kombiniert die Build Tools von [mingw-w64](https://www.mingw-w64.org) mit einer UNIX Umgebung.

Unterschied zu WSL:  
WSL ist eine VM und der Output sind Linux Binaries.  
Die [mingw-w64](https://www.mingw-w64.org) Build Tools bauen **Windows Binaries**.